### PR TITLE
Start

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,6 @@
     "webpack": "^1.13.1"
   },
   "scripts": {
-    "postinstall": "webpack --watch"
+    "start": "webpack --watch"
   }
 }


### PR DESCRIPTION
When installing the package, it starts running immediately - which isn't desired behavior. When installing you simply want to install. When working on the package itself you can use `npm start`.